### PR TITLE
Replaced bank number with BIC and account number with IBAN

### DIFF
--- a/models/invoicepdfoxorder.php
+++ b/models/invoicepdfoxorder.php
@@ -126,8 +126,8 @@ class InvoicepdfOxOrder extends InvoicepdfOxOrder_parent
 
         /* column 3 - bank information */
         $oPdf->text(150, 275, strip_tags($oShop->oxshops__oxbankname->getRawValue()));
-        $oPdf->text(150, 278, $this->translate('ORDER_OVERVIEW_PDF_ACCOUNTNR') . strip_tags($oShop->oxshops__oxbanknumber->value));
-        $oPdf->text(150, 281, $this->translate('ORDER_OVERVIEW_PDF_BANKCODE') . strip_tags($oShop->oxshops__oxbankcode->value));
+        $oPdf->text(150, 278, $this->translate('ORDER_OVERVIEW_PDF_ACCOUNTNR') . strip_tags($oShop->oxshops__oxibannumber->value));
+        $oPdf->text(150, 281, $this->translate('ORDER_OVERVIEW_PDF_BANKCODE') . strip_tags($oShop->oxshops__oxbiccode->value));
         $oPdf->text(150, 284, $this->translate('ORDER_OVERVIEW_PDF_VATID') . strip_tags($oShop->oxshops__oxvatnumber->value));
         $oPdf->text(150, 287, $this->translate('ORDER_OVERVIEW_PDF_TAXID') . strip_tags($oShop->oxshops__oxtaxnumber->value));
     }


### PR DESCRIPTION
The change is made, the fish is cleaned up: IBAN and BIC finally replaced bank and account numbers. And exactly this is what should appear in PDF invoice, nothing else.