### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ PDF invoice module for OXID eShop.
 ### Requirements
 
 * OXID eShop v6.*
+* PHP 7.*
 
 ## Installation
 


### PR DESCRIPTION
Its not working on PHP 5.6 ( public function getElementsTabber(): Tabber ) Return Type declaration is only available in PHP 7