### PR TITLE
PDF generation should not fail if the logo file is missing in the...

### DIFF
--- a/models/invoicepdfoxorder.php
+++ b/models/invoicepdfoxorder.php
@@ -187,13 +187,14 @@ class InvoicepdfOxOrder extends InvoicepdfOxOrder_parent
         $oShop = $this->_getActShop();
         
         $myConfig = $this->getConfig();
-        $aSize = getimagesize($myConfig->getImageDir() . '/pdf_logo.jpg');
+        $pdfLogoPath = $this->getConfig()->getImagePath('pdf_logo.jpg');
+        $aSize = getimagesize($pdfLogoPath);
             
         //logo
         if ($myConfig->getRequestParameter('pdftype') == 'standart' or $myConfig->getRequestParameter('pdftype') == 'dnote') {
             $iMargin = 195 - $aSize[0] * 0.2;
             $oPdf->setLink($oShop->oxshops__oxurl->value);
-            $oPdf->image($myConfig->getImageDir() . '/pdf_logo.jpg', $iMargin, 10, $aSize[0] * 0.2, $aSize[1] * 0.2, '', $oShop->oxshops__oxurl->value);
+            $oPdf->image($pdfLogoPath, $iMargin, 10, $aSize[0] * 0.2, $aSize[1] * 0.2, '', $oShop->oxshops__oxurl->value);
         }
         return 14 + $aSize[1] * 0.2;
     }


### PR DESCRIPTION
...child theme but existing in the parent theme.
Please see issue #7 .

The current approach to get the path of a picture is this: 
`$myConfig->getImageDir() . '/pdf_logo.jpg'`
But with this way it will always return the path of the current theme, like:
`/out/mytheme/img/ . 'pdf_logo.jpg'.`

If "mytheme" is a child theme and doesn't contain an own PDF logo file, the module should use the fallback mechanism of the shop framework and using the file from the parent theme. This is achieved by using `Config::getImagePath('pdf_logo.jpg').`