### PR TITLE
Pdf oxdellname

### DIFF
--- a/controllers/admin/invoicepdforder_overview.php
+++ b/controllers/admin/invoicepdforder_overview.php
@@ -77,7 +77,7 @@ class InvoicepdfOrder_Overview extends InvoicepdfOrder_Overview_parent
             if ($oOrder->load($soxId)) {
                 $oUtils = \OxidEsales\Eshop\Core\Registry::getUtils();
                 $sTrimmedBillName = trim($oOrder->oxorder__oxbilllname->getRawValue());
-                $sFilename = $oOrder->oxorder__oxordernr->value . "_" . $sTrimmedBillName . ".pdf";
+                $sFilename = utf8_decode($oOrder->oxorder__oxordernr->value . "_" . $sTrimmedBillName . ".pdf");
                 $sFilename = $this->makeValidFileName($sFilename);
                 ob_start();
                 $oOrder->genPDF($sFilename, \OxidEsales\Eshop\Core\Registry::getConfig()->getRequestParameter("pdflanguage"));

--- a/models/invoicepdfoxorder.php
+++ b/models/invoicepdfoxorder.php
@@ -409,7 +409,7 @@ class InvoicepdfOxOrder extends InvoicepdfOxOrder_parent
         $this->_setBillingAddressToPdf($oPdf);
 
         // delivery address
-        if ($this->oxorder__oxdelsal->value) {
+        if ($this->oxorder__oxdellname->value) {
             $this->_setDeliveryAddressToPdf($oPdf);
         }
 

--- a/models/invoicepdfoxorder.php
+++ b/models/invoicepdfoxorder.php
@@ -296,9 +296,9 @@ class InvoicepdfOxOrder extends InvoicepdfOxOrder_parent
     protected function _setDeliveryAddressToPdf($oPdf)
     {
         $oLang = \OxidEsales\Eshop\Core\Registry::getLang();
-        $sSal = $this->oxorder__oxdelsal->value;
+        $sSal = $this->oxorder__oxdelname->value;
         try {
-            $sSal = $oLang->translateString($this->oxorder__oxdelsal->value, $this->getSelectedLang());
+            $sSal = $oLang->translateString($this->oxorder__oxdelname->value, $this->getSelectedLang());
         } catch (Exception $e) {
         }
         $oPdfBlock = oxNew('InvoicepdfBlock');


### PR DESCRIPTION
#16 The change from "oxdelsal" to "oxdellname" as a mandatory field for the delivery address.
This adjustment causes a reliable output of the delivery address in the pdf invoice. Since the field oxdelsal is not a mandatory field, the delivery address is repeatedly not output.
A family name is always given.