### PR TITLE
zeile 424: Mandatory field oxdelsal changed to oxdellname

### DIFF
--- a/models/invoicepdfoxorder.php
+++ b/models/invoicepdfoxorder.php
@@ -421,7 +421,7 @@ class InvoicepdfOxOrder extends InvoicepdfOxOrder_parent
         $this->_setBillingAddressToPdf($oPdf);
 
         // delivery address
-        if ($this->oxorder__oxdelsal->value) {
+        if ($this->oxorder__oxdellname->value) {
             $this->_setDeliveryAddressToPdf($oPdf);
         }
 


### PR DESCRIPTION
The change from "oxdelsal" to "oxdellname" as a mandatory field for the delivery address.
This adjustment causes a reliable output of the delivery address in the pdf invoice. Since the field oxdelsal is not a mandatory field, the delivery address is repeatedly not output.
A family name is always given.